### PR TITLE
パッケージのインストールタイミングに関わらずパッケージのバージョンが固定されるようにlockファイルをgitで管理する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # dependencies
 /node_modules
-package-lock.json
-yarn.lock
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
現状 yarn.lock や package.lock.json がignoreされていて、npm install ないし yarn install する際に、インストールされるパッケージの差分が生じる。
タイミングによってビルドが通らなくなったり、ライブラリの挙動が変わるなどの問題が発生するためこれらのファイルは管理したほうが良いだろう。