### PR TITLE
style TimeTable rest block to small

### DIFF
--- a/static/Schedule.module.scss
+++ b/static/Schedule.module.scss
@@ -12,18 +12,18 @@
     grid-template-rows:
       [tracks] auto
       [time-1300] 1fr
-      [time-1320] 1fr
+      [time-1320] auto
       [time-1330] 1fr
-      [time-1400] 1fr
+      [time-1400] auto
       [time-1410] 1fr
       [time-1425] 1fr
-      [time-1440] 1fr
+      [time-1440] auto
       [time-1450] 1fr
-      [time-1520] 1fr
+      [time-1520] auto
       [time-1530] 1fr
-      [time-1600] 1fr
+      [time-1600] auto
       [time-1610] 1fr
-      [time-1640] 1fr
+      [time-1640] auto
       [time-1650] 1fr;
 
     grid-template-columns:


### PR DESCRIPTION
before
<img width="400" alt="Screen Shot 2021-11-19 at 15 34 22" src="https://user-images.githubusercontent.com/2284908/142578126-1af389b0-6865-4143-b02d-6d204ca8bdec.png">

after
<img width="400" alt="Screen Shot 2021-11-19 at 15 34 17" src="https://user-images.githubusercontent.com/2284908/142578134-06b91e1a-81db-4b77-b7e5-4d66fee557a0.png">

