### PR TITLE
Fix Video Player width

### DIFF
--- a/components/Player.tsx
+++ b/components/Player.tsx
@@ -5,7 +5,7 @@ import styles from '../static/Player.module.scss'
 const Player: FC = () => {
   return (
     <div id={'player'} className={styles.player}>
-      <ReactPlayer url="https://youtu.be/Y8dl1y2qdG8" />
+      <ReactPlayer width={'100%'} url="https://youtu.be/Y8dl1y2qdG8" />
     </div>
   )
 }

--- a/static/Player.module.scss
+++ b/static/Player.module.scss
@@ -5,6 +5,11 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
+
+  .player-wrapper {
+    width: 100%;
+    max-width: 640px;
+  }
 }
 
 .player h2 {

--- a/static/Player.module.scss
+++ b/static/Player.module.scss
@@ -5,11 +5,8 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-
-  .player-wrapper {
-    width: 100%;
-    max-width: 640px;
-  }
+  margin-top: 16px;
+  max-width: 640px;
 }
 
 .player h2 {
@@ -25,7 +22,6 @@
 @media (max-width: 600px) {
   .player {
     position: relative;
-    width: 360px;
     max-width: 100%;
     iframe {
       position: absolute;


### PR DESCRIPTION
### before

under 600px

<img width="527" alt="Screen Shot 2021-11-19 at 15 55 08" src="https://user-images.githubusercontent.com/2284908/142580543-ab1c7e19-3680-45e4-ae42-48a127d4c609.png">


### after
<img width="527" alt="Screen Shot 2021-11-19 at 16 10 26" src="https://user-images.githubusercontent.com/2284908/142580607-1bdd3040-f6a9-4b03-b3b2-bf36331163bb.png">
<img width="830" alt="Screen Shot 2021-11-19 at 16 10 45" src="https://user-images.githubusercontent.com/2284908/142580612-4dd6b2fe-47ee-4ed4-bef0-d7373c614f98.png">

